### PR TITLE
fix: Add flex div wrapper

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -306,41 +306,45 @@ export default function Home() {
                     new Intl.NumberFormat("en-US").format(application.pay)
                   )}
                 </td>
-                <td className="flex flex-row flex-nowrap  justify-center items-center space-x-2">
-                  {editingId === application.id ? (
-                    // Render the Save button only if we're in edit mode for this row
-                    <button
-                      className="px-4 py-2 bg-green-500 text-white rounded-md hover:bg-green-700"
-                      onClick={() => handleSave(application.id)}
-                    >
-                      Save
-                    </button>
-                  ) : (
-                    // Otherwise, render the Edit button which is always visible
-                    <button
-                      className="px-4 py-2 m-2 bg-yellow-500 text-white rounded-md hover:bg-yellow-700"
-                      onClick={() => handleEdit(application)}
-                    >
-                      Edit
-                    </button>
-                  )}
+                <td>
+                  <div className="flex justify-center items-center">
+                    {editingId === application.id ? (
+                      // Render the Save button only if we're in edit mode for this row
+                      <button
+                        className="px-4 py-2 bg-green-500 text-white rounded-md hover:bg-green-700"
+                        onClick={() => handleSave(application.id)}
+                      >
+                        Save
+                      </button>
+                    ) : (
+                      // Otherwise, render the Edit button which is always visible
+                      <button
+                        className="px-4 py-2 m-2 bg-yellow-500 text-white rounded-md hover:bg-yellow-700"
+                        onClick={() => handleEdit(application)}
+                      >
+                        Edit
+                      </button>
+                    )}
+                  </div>
                 </td>
                 <td>
-                  {deletingId === application.id ? (
-                    <button
-                      className="px-4 py-2 mt-2 bg-red-500 text-white rounded-md hover:bg-red-700"
-                      onClick={() => handleConfirmDelete(application.id)}
-                    >
-                      Confirm
-                    </button>
-                  ) : (
-                    <button
-                      className="px-4 py-2 mt-2 bg-red-500 text-white rounded-md hover:bg-red-700"
-                      onClick={() => setDeletingId(application.id)}
-                    >
-                      Delete
-                    </button>
-                  )}
+                  <div className="flex justify-center items-center">
+                    {deletingId === application.id ? (
+                      <button
+                        className="px-4 py-2 bg-red-500 text-white rounded-md hover:bg-red-700"
+                        onClick={() => handleConfirmDelete(application.id)}
+                      >
+                        Confirm
+                      </button>
+                    ) : (
+                      <button
+                        className="px-4 py-2 bg-red-500 text-white rounded-md hover:bg-red-700"
+                        onClick={() => setDeletingId(application.id)}
+                      >
+                        Delete
+                      </button>
+                    )}
+                  </div>
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
The change removes the classNames from your td element, I think it's because table cells behave a little differently and that was causing it to get fucked up. That's probably why GPT got caught in a loop thinking you had something else causing it.

You can put your elements inside another div within the td and apply the flex styles to that to position it centrally:

```
<td>
  <div className="flex justify-center items-center">
    {deletingId === application.id ? (
      <button
        className="px-4 py-2 bg-red-500 text-white rounded-md hover:bg-red-700"
        onClick={() => handleConfirmDelete(application.id)}
      >
        Confirm
      </button>
    ) : (
      <button
        className="px-4 py-2 bg-red-500 text-white rounded-md hover:bg-red-700"
        onClick={() => setDeletingId(application.id)}
      >
        Delete
      </button>
    )}
  </div>
</td>
```
